### PR TITLE
Set default selection

### DIFF
--- a/src/BinaryChart.js
+++ b/src/BinaryChart.js
@@ -41,11 +41,13 @@ export default class BinaryChart extends Component {
         const config = initChart(newProps || this.props);
         config.chart.renderTo = this.refs.chart;
         this.chart = new Highcharts.StockChart(config);
+        
     }
 
     componentDidMount() {
         this.createChart();
         updateChart(this.chart, { ticks: [] }, this.props);
+        this.chart.rangeSelector.clickButton(0, 0, true);
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
Hi,

Attached contained few changes that should enable us select default option from our range option. The selected option should have done the task for us, it failed because our chart has not been set yet. Just the options which are merely a js object. Setting a clicked among the options after the chart is mounted should do the trick.